### PR TITLE
Fixed formating for rockloader.md

### DIFF
--- a/Http Botnets/rockloaded.md
+++ b/Http Botnets/rockloaded.md
@@ -2,7 +2,6 @@
 
 Type: Bling sql injection on username
 
-`-1' OR 2*2*1=4 AND 123=123--`
+SQL string: `-1' OR 2*2*1=4 AND 123=123--`
+
 ![](http://i.imgur.com/znYe3lS.jpg "rockloader")
-
-


### PR DESCRIPTION
The markdown for rockerloader.md cause the sql injection string to be displayed next to instead of above the picture. 